### PR TITLE
feat: Add missing params for SNS subscriptions + tf fmt

### DIFF
--- a/sns.tf
+++ b/sns.tf
@@ -69,8 +69,12 @@ resource "aws_sns_topic_policy" "tre_out" {
 }
 
 resource "aws_sns_topic_subscription" "tre_out" {
-  for_each  = { for sub in var.tre_out_subscriptions : sub.name => sub }
-  topic_arn = aws_sns_topic.tre_out.arn
-  protocol  = each.value.protocol
-  endpoint  = each.value.endpoint
+  for_each              = { for sub in var.tre_out_subscriptions : sub.name => sub }
+  topic_arn             = aws_sns_topic.tre_out.arn
+  protocol              = each.value.protocol
+  endpoint              = each.value.endpoint
+  filter_policy         = each.value.filter_policy
+  filter_policy_scope   = each.value.filter_policy_scope
+  raw_message_delivery  = each.value.raw_message_delivery
+  subscription_role_arn = each.value.subscription_role_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,9 +90,13 @@ variable "tre_internal_subscriptions" {
 variable "tre_out_subscriptions" {
   description = "List tre-out topic subscriptions"
   type = list(object({
-    name     = string
-    endpoint = string
-    protocol = string
+    name                  = string
+    endpoint              = string
+    protocol              = string
+    filter_policy         = any
+    filter_policy_scope   = string
+    raw_message_delivery  = bool
+    subscription_role_arn = string
   }))
 }
 
@@ -106,15 +110,15 @@ variable "tre_out_subscribers" {
 
 variable "tre_permission_boundary_arn" {
   description = "ARN of the TRE permission boundary policy"
-  type = string
+  type        = string
 }
 
 variable "ecr_uri_host" {
   description = "The hostname part of the management account ECR repository; e.g. ACCOUNT.dkr.ecr.REGION.amazonaws.com"
-  type = string
+  type        = string
 }
 
 variable "ecr_uri_repo_prefix" {
   description = "The prefix for Docker image repository names to use; e.g. foo/ in ACCOUNT.dkr.ecr.REGION.amazonaws.com/foo/tre-bar"
-  type = string
+  type        = string
 }


### PR DESCRIPTION
Not sure why but all the params were being passed to create a subscription on tre_out.  Assume because it was unused hitherto