### PR TITLE
allow multiple publishers

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -13,15 +13,18 @@ data "aws_iam_policy_document" "common_tre_slack_alerts_sns_topic_policy" {
 }
 
 data "aws_iam_policy_document" "tre_in_topic_policy" {
-  statement {
-    sid     = "TRE-InPublishers"
-    actions = ["sns:Publish"]
-    effect  = "Allow"
-    principals {
-      type        = "AWS"
-      identifiers = var.tre_in_publishers
+  dynamic "statement" {
+    for_each = var.tre_in_publishers
+    content {
+      sid     = statement.value["sid"]
+      actions = ["sns:Publish"]
+      effect  = "Allow"
+      principals {
+        type        = "AWS"
+        identifiers = statement.value["principal_identifier"]
+      }
+      resources = [aws_sns_topic.tre_in.arn]
     }
-    resources = [aws_sns_topic.tre_in.arn]
   }
 }
 


### PR DESCRIPTION
Using dynamic statement to allow multiple publishers
the tfvars will be updated in AWS parameter store
"tre_in_publishers":[
      {
         "sid":"TRE-InPublishers",
         "principal_identifier":[
            "arn:aws:iam::454286877087:root"
         ]
      },
      {
         "sid":"FCL-InPublishers",
         "principal_identifier":[
            "arn:aws:iam::276505630421:root"
         ]
      }
   ],
from 
"tre_in_publishers":[
      "arn:aws:iam::454286877087:root"
   ],