### PR TITLE
DTE-844: success and failure lambdas

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -120,6 +120,23 @@ resource "aws_iam_role_policy_attachment" "tre_success_lambda_logs" {
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
 
+data "aws_iam_policy_document" "success_lambda_invoke_policy_data" {
+  statement {
+    sid     = "InvokeLambdaPolicy"
+    effect  = "Allow"
+    actions = ["lambda:InvokeFunction"]
+    resources = [
+      var.tre_court_document_pre_packer_lambda_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "pre_packer_lambda_invoke_policy" {
+  name        = "${var.env}-${var.prefix}-success-lambda-invoke"
+  description = "The policy for pre packer lambda to invoke success lambda"
+  policy      = data.aws_iam_policy_document.success_lambda_invoke_policy_data.json
+}
+
 
 # S3 Policy
 

--- a/iam.tf
+++ b/iam.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "tre_internal_topic_policy" {
     effect  = "Allow"
     principals {
       type        = "AWS"
-      identifiers = concat(var.tre_internal_publishers, [aws_iam_role.tre_success_handler_lambda.arn, aws_iam_role.tre_failure_handler_lambda.arn])
+      identifiers = concat(var.tre_internal_publishers, [aws_iam_role.success_destination_lambda.arn, aws_iam_role.failure_destination_lambda.arn])
     }
     resources = [aws_sns_topic.tre_internal.arn]
   }
@@ -109,25 +109,25 @@ resource "aws_iam_role_policy_attachment" "tre_dlq_alerts_lambda" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
 }
 
-resource "aws_iam_role" "tre_success_handler_lambda" {
-  name                 = "${var.env}-${var.prefix}-success-handler-role"
+resource "aws_iam_role" "success_destination_lambda" {
+  name                 = "${var.env}-${var.prefix}-success-destination-role"
   assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role_policy.json
   permissions_boundary = var.tre_permission_boundary_arn
 }
 
-resource "aws_iam_role_policy_attachment" "tre_success_lambda_logs" {
-  role       = aws_iam_role.tre_success_handler_lambda.name
+resource "aws_iam_role_policy_attachment" "success_destination_lambda_logs" {
+  role       = aws_iam_role.success_destination_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
 
-resource "aws_iam_role" "tre_failure_handler_lambda" {
-  name                 = "${var.env}-${var.prefix}-failure-handler-role"
+resource "aws_iam_role" "failure_destination_lambda" {
+  name                 = "${var.env}-${var.prefix}-failure-destination-role"
   assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role_policy.json
   permissions_boundary = var.tre_permission_boundary_arn
 }
 
-resource "aws_iam_role_policy_attachment" "tre_failure_lambda_logs" {
-  role       = aws_iam_role.tre_failure_handler_lambda.name
+resource "aws_iam_role_policy_attachment" "failure_destination_lambda_logs" {
+  role       = aws_iam_role.failure_destination_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -137,6 +137,35 @@ resource "aws_iam_policy" "pre_packer_lambda_invoke_policy" {
   policy      = data.aws_iam_policy_document.success_lambda_invoke_policy_data.json
 }
 
+resource "aws_iam_role" "tre_failure_handler_lambda" {
+  name                 = "${var.env}-${var.prefix}-failure-handler-role"
+  assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role_policy.json
+  permissions_boundary = var.tre_permission_boundary_arn
+}
+
+resource "aws_iam_role_policy_attachment" "tre_failure_lambda_logs" {
+  role       = aws_iam_role.tre_failure_handler_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
+}
+
+data "aws_iam_policy_document" "failure_lambda_invoke_policy_data" {
+  statement {
+    sid     = "InvokeLambdaPolicy"
+    effect  = "Allow"
+    actions = ["lambda:InvokeFunction"]
+    resources = [
+      var.tre_court_document_pre_packer_lambda_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "pre_packer_lambda_invoke_policy" {
+  name        = "${var.env}-${var.prefix}-failure-lambda-invoke"
+  description = "The policy for pre packer lambda to invoke failure lambda"
+  policy      = data.aws_iam_policy_document.failure_lambda_invoke_policy_data.json
+}
+
+
 
 # S3 Policy
 

--- a/iam.tf
+++ b/iam.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "tre_internal_topic_policy" {
     effect  = "Allow"
     principals {
       type        = "AWS"
-      identifiers = concat(var.tre_internal_publishers, [aws_iam_role.tre_success_handler_lambda.arn])
+      identifiers = concat(var.tre_internal_publishers, [aws_iam_role.tre_success_handler_lambda.arn, aws_iam_role.tre_failure_handler_lambda.arn])
     }
     resources = [aws_sns_topic.tre_internal.arn]
   }

--- a/iam.tf
+++ b/iam.tf
@@ -120,24 +120,6 @@ resource "aws_iam_role_policy_attachment" "tre_success_lambda_logs" {
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
 
-# these next two are not needed
-data "aws_iam_policy_document" "success_lambda_invoke_policy_data" {
-  statement {
-    sid     = "InvokeLambdaPolicy"
-    effect  = "Allow"
-    actions = ["lambda:InvokeFunction"]
-    resources = [
-      var.tre_court_document_pre_packer_lambda_arn
-    ]
-  }
-}
-
-resource "aws_iam_policy" "pre_packer_lambda_invoke_policy" {
-  name        = "${var.env}-${var.prefix}-success-lambda-invoke"
-  description = "The policy for pre packer lambda to invoke success lambda"
-  policy      = data.aws_iam_policy_document.success_lambda_invoke_policy_data.json
-}
-
 resource "aws_iam_role" "tre_failure_handler_lambda" {
   name                 = "${var.env}-${var.prefix}-failure-handler-role"
   assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role_policy.json
@@ -148,26 +130,6 @@ resource "aws_iam_role_policy_attachment" "tre_failure_lambda_logs" {
   role       = aws_iam_role.tre_failure_handler_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
-
-# these next two are not needed
-data "aws_iam_policy_document" "failure_lambda_invoke_policy_data" {
-  statement {
-    sid     = "InvokeLambdaPolicy"
-    effect  = "Allow"
-    actions = ["lambda:InvokeFunction"]
-    resources = [
-      var.tre_court_document_pre_packer_lambda_arn
-    ]
-  }
-}
-
-resource "aws_iam_policy" "pre_packer_lambda_failure_invoke_policy" {
-  name        = "${var.env}-${var.prefix}-failure-lambda-invoke"
-  description = "The policy for pre packer lambda to invoke failure lambda"
-  policy      = data.aws_iam_policy_document.failure_lambda_invoke_policy_data.json
-}
-
-
 
 # S3 Policy
 

--- a/iam.tf
+++ b/iam.tf
@@ -120,6 +120,7 @@ resource "aws_iam_role_policy_attachment" "tre_success_lambda_logs" {
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
 
+# these next two are not needed
 data "aws_iam_policy_document" "success_lambda_invoke_policy_data" {
   statement {
     sid     = "InvokeLambdaPolicy"
@@ -148,6 +149,7 @@ resource "aws_iam_role_policy_attachment" "tre_failure_lambda_logs" {
   policy_arn = "arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs"
 }
 
+# these next two are not needed
 data "aws_iam_policy_document" "failure_lambda_invoke_policy_data" {
   statement {
     sid     = "InvokeLambdaPolicy"

--- a/iam.tf
+++ b/iam.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "failure_lambda_invoke_policy_data" {
   }
 }
 
-resource "aws_iam_policy" "pre_packer_lambda_invoke_policy" {
+resource "aws_iam_policy" "pre_packer_lambda_failure_invoke_policy" {
   name        = "${var.env}-${var.prefix}-failure-lambda-invoke"
   description = "The policy for pre packer lambda to invoke failure lambda"
   policy      = data.aws_iam_policy_document.failure_lambda_invoke_policy_data.json

--- a/lambda.tf
+++ b/lambda.tf
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "tre_dlq_slack_alerts" {
 }
 
 resource "aws_lambda_function" "tre_success_handler" {
-  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}mk-junk-example:1.0.14"
+  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}mk-junk-example:1.0.20"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-success-handler"
   role          = aws_iam_role.tre_success_handler_lambda.arn

--- a/lambda.tf
+++ b/lambda.tf
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "tre_dlq_slack_alerts" {
 }
 
 resource "aws_lambda_function" "tre_success_handler" {
-  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}mk-junk-example:1.0.22"
+  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}mk-junk-example:1.0.30"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-success-handler"
   role          = aws_iam_role.tre_success_handler_lambda.arn

--- a/lambda.tf
+++ b/lambda.tf
@@ -48,10 +48,31 @@ resource "aws_lambda_function" "tre_dlq_slack_alerts" {
 }
 
 resource "aws_lambda_function" "tre_success_handler" {
-  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}mk-junk-example:1.0.30"
+  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}da-tre-fn-success-destination:${var.success_destination_image_versions.success_destination}"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-success-handler"
   role          = aws_iam_role.tre_success_handler_lambda.arn
+  memory_size   = 1024
+  timeout       = 30
+  environment {
+    variables = {
+      "TRE_INTERNAL_TOPIC_ARN" = aws_sns_topic.tre_internal.arn
+    }
+  }
+  tracing_config {
+    mode = "Active"
+  }
+
+  tags = {
+    "ApplicationType" = "Scala"
+  }
+}
+
+resource "aws_lambda_function" "tre_failure_handler" {
+  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}da-tre-fn-failure-destination:${var.failure_destination_image_versions.failure_destination}"
+  package_type  = "Image"
+  function_name = "${var.env}-${var.prefix}-failure-handler"
+  role          = aws_iam_role.tre_failure_handler_lambda.arn
   memory_size   = 1024
   timeout       = 30
   environment {

--- a/lambda.tf
+++ b/lambda.tf
@@ -47,11 +47,11 @@ resource "aws_lambda_function" "tre_dlq_slack_alerts" {
   }
 }
 
-resource "aws_lambda_function" "tre_success_handler" {
+resource "aws_lambda_function" "success_destination" {
   image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}da-tre-fn-success-destination:${var.success_destination_image_versions.success_destination}"
   package_type  = "Image"
-  function_name = "${var.env}-${var.prefix}-success-handler"
-  role          = aws_iam_role.tre_success_handler_lambda.arn
+  function_name = "${var.env}-${var.prefix}-success-destination"
+  role          = aws_iam_role.success_destination_lambda.arn
   memory_size   = 1024
   timeout       = 30
   environment {
@@ -68,11 +68,11 @@ resource "aws_lambda_function" "tre_success_handler" {
   }
 }
 
-resource "aws_lambda_function" "tre_failure_handler" {
+resource "aws_lambda_function" "failure_destination" {
   image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}da-tre-fn-failure-destination:${var.failure_destination_image_versions.failure_destination}"
   package_type  = "Image"
-  function_name = "${var.env}-${var.prefix}-failure-handler"
-  role          = aws_iam_role.tre_failure_handler_lambda.arn
+  function_name = "${var.env}-${var.prefix}-failure-destination"
+  role          = aws_iam_role.failure_destination_lambda.arn
   memory_size   = 1024
   timeout       = 30
   environment {

--- a/lambda.tf
+++ b/lambda.tf
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "tre_dlq_slack_alerts" {
 }
 
 resource "aws_lambda_function" "tre_success_handler" {
-  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}mk-junk-example:1.0.20"
+  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}mk-junk-example:1.0.22"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-success-handler"
   role          = aws_iam_role.tre_success_handler_lambda.arn

--- a/output.tf
+++ b/output.tf
@@ -32,3 +32,8 @@ output "success_handler_lambda_arn" {
   value       = aws_lambda_function.tre_success_handler.arn
   description = "Success handler Lambda ARN"
 }
+
+output "failure_handler_lambda_arn" {
+  value       = aws_lambda_function.tre_failure_handler.arn
+  description = "Failure handler Lambda ARN"
+}

--- a/output.tf
+++ b/output.tf
@@ -28,12 +28,12 @@ output "tre_dlq_alerts_lambda_function_name" {
   description = "TRE DLQ Alerts Lambda Function Name"
 }
 
-output "success_handler_lambda_arn" {
-  value       = aws_lambda_function.tre_success_handler.arn
-  description = "Success handler Lambda ARN"
+output "success_destination_lambda_arn" {
+  value       = aws_lambda_function.success_destination.arn
+  description = "Success destination Lambda ARN"
 }
 
-output "failure_handler_lambda_arn" {
-  value       = aws_lambda_function.tre_failure_handler.arn
-  description = "Failure handler Lambda ARN"
+output "failure_destination_lambda_arn" {
+  value       = aws_lambda_function.failure_destination.arn
+  description = "Failure destination Lambda ARN"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,8 @@ variable "ecr_uri_repo_prefix" {
   description = "The prefix for Docker image repository names to use; e.g. foo/ in ACCOUNT.dkr.ecr.REGION.amazonaws.com/foo/tre-bar"
   type        = string
 }
+
+variable "tre_court_document_pre_packer_lambda_arn" {
+  description = "The pre packer lambda arn"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,13 +25,13 @@ variable "common_image_versions" {
   })
 }
 variable "success_destination_image_versions" {
-  description = "Latest version of Images for the court document success destination Lambda Functions"
+  description = "Latest version of Images for the success destination Lambda Functions"
   type = object({
     success_destination = string
   })
 }
 variable "failure_destination_image_versions" {
-  description = "Latest version of Images for the court document failure destination Lambda Functions"
+  description = "Latest version of Images for the failure destination Lambda Functions"
   type = object({
     failure_destination = string
   })
@@ -134,10 +134,5 @@ variable "ecr_uri_host" {
 
 variable "ecr_uri_repo_prefix" {
   description = "The prefix for Docker image repository names to use; e.g. foo/ in ACCOUNT.dkr.ecr.REGION.amazonaws.com/foo/tre-bar"
-  type        = string
-}
-
-variable "tre_court_document_pre_packer_lambda_arn" {
-  description = "The pre packer lambda arn"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,18 @@ variable "common_image_versions" {
     tre_dlq_slack_alerts = string
   })
 }
+variable "success_destination_image_versions" {
+  description = "Latest version of Images for the court document success destination Lambda Functions"
+  type = object({
+    success_destination = string
+  })
+}
+variable "failure_destination_image_versions" {
+  description = "Latest version of Images for the court document failure destination Lambda Functions"
+  type = object({
+    failure_destination = string
+  })
+}
 
 variable "tre_slack_alerts_publishers" {
   description = "Roles that have permission to publish messages to tre-slack-alerts topic"


### PR DESCRIPTION
- makes the success and failure destination lambdas
- allows them to publish to internal
- outputs the arns for other modules to use