### PR TITLE
feat: Configure subscribers to new da eventbus topic; switch success destination publish topic arn to da eventbus from internal

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -229,12 +229,6 @@ data "aws_iam_policy_document" "tre_out_sns_kms_key" {
   }
 }
 
-
-resource "aws_sns_topic_policy" "da_eventbus" {
-  arn    = aws_sns_topic.da_eventbus.arn
-  policy = data.aws_iam_policy_document.da_eventbus_topic_policy.json
-}
-
 data "aws_iam_policy_document" "da_eventbus_topic_policy" {
   dynamic "statement" {
     for_each = var.da_eventbus_client_account_ids

--- a/iam.tf
+++ b/iam.tf
@@ -60,19 +60,6 @@ data "aws_iam_policy_document" "tre_out_topic_policy" {
   }
 }
 
-data "aws_iam_policy_document" "da_eventbus_topic_policy" {
-  statement {
-    sid     = "DA-EventbusPublishers"
-    actions = ["sns:Publish"]
-    effect  = "Allow"
-    principals {
-      type        = "AWS"
-      identifiers = var.da_eventbus_publishers
-    }
-    resources = [aws_sns_topic.da_eventbus.arn]
-  }
-}
-
 data "aws_iam_policy_document" "tre_internal_topic_policy" {
   statement {
     sid     = "TRE-InternalPublishers"
@@ -231,7 +218,7 @@ data "aws_iam_policy_document" "tre_out_sns_kms_key" {
 
 data "aws_iam_policy_document" "da_eventbus_topic_policy" {
   dynamic "statement" {
-    for_each = var.da_eventbus_client_account_ids
+    for_each = concat(var.da_eventbus_client_account_ids, var.da_eventbus_publishers)
     content {
       sid     = "da-event-bus-client-${statement.value}"
       actions = [

--- a/iam.tf
+++ b/iam.tf
@@ -258,7 +258,13 @@ data "aws_iam_policy_document" "da_eventbus_topic_policy" {
 data "aws_iam_policy_document" "da_eventbus_kms_key" {
 
   dynamic "statement" {
-    for_each = toset(var.da_eventbus_client_account_ids)
+    for_each = toset(
+      concat(
+        var.da_eventbus_client_account_ids,
+        var.da_eventbus_publishers,
+        [aws_iam_role.success_destination_lambda.arn]
+      )
+    )
     content {
       sid     = "da-event-bus-key-policy-${statement.value}"
       actions = [

--- a/iam.tf
+++ b/iam.tf
@@ -258,7 +258,7 @@ data "aws_iam_policy_document" "da_eventbus_topic_policy" {
 data "aws_iam_policy_document" "da_eventbus_kms_key" {
 
   dynamic "statement" {
-    for_each = toset(var.da_eventbus_client_account_ids, var.account_id)
+    for_each = toset(concat(var.da_eventbus_client_account_ids, [var.account_id]))
     content {
       sid     = "da-event-bus-key-policy-${statement.value}"
       actions = [

--- a/iam.tf
+++ b/iam.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "tre_internal_topic_policy" {
     effect  = "Allow"
     principals {
       type        = "AWS"
-      identifiers = concat(var.tre_internal_publishers, [aws_iam_role.success_destination_lambda.arn, aws_iam_role.failure_destination_lambda.arn])
+      identifiers = concat(var.tre_internal_publishers, [aws_iam_role.failure_destination_lambda.arn])
     }
     resources = [aws_sns_topic.tre_internal.arn]
   }
@@ -218,7 +218,11 @@ data "aws_iam_policy_document" "tre_out_sns_kms_key" {
 
 data "aws_iam_policy_document" "da_eventbus_topic_policy" {
   dynamic "statement" {
-    for_each = concat(var.da_eventbus_client_account_ids, var.da_eventbus_publishers)
+    for_each = concat(
+      var.da_eventbus_client_account_ids, 
+      var.da_eventbus_publishers, 
+      [aws_iam_role.success_destination_lambda.arn]
+    )
     content {
       sid     = "da-event-bus-client-${statement.value}"
       actions = [

--- a/iam.tf
+++ b/iam.tf
@@ -263,7 +263,8 @@ data "aws_iam_policy_document" "da_eventbus_kms_key" {
       sid     = "da-event-bus-key-policy-${statement.value}"
       actions = [
         "kms:Decrypt",
-        "kms:Encrypt"
+        "kms:Encrypt",
+        "kms:GenerateDataKey*"
       ]
       effect = "Allow"
       principals {

--- a/iam.tf
+++ b/iam.tf
@@ -258,12 +258,7 @@ data "aws_iam_policy_document" "da_eventbus_topic_policy" {
 data "aws_iam_policy_document" "da_eventbus_kms_key" {
 
   dynamic "statement" {
-    for_each = toset(
-      concat(
-        var.da_eventbus_client_account_ids,
-        [aws_iam_role.success_destination_lambda.arn]
-      )
-    )
+    for_each = toset(var.da_eventbus_client_account_ids, var.account_id)
     content {
       sid     = "da-event-bus-key-policy-${statement.value}"
       actions = [

--- a/iam.tf
+++ b/iam.tf
@@ -258,13 +258,12 @@ data "aws_iam_policy_document" "da_eventbus_topic_policy" {
 data "aws_iam_policy_document" "da_eventbus_kms_key" {
 
   dynamic "statement" {
-    for_each = toset(concat(var.da_eventbus_client_account_ids, [var.account_id]))
+    for_each = toset(var.da_eventbus_client_account_ids)
     content {
       sid     = "da-event-bus-key-policy-${statement.value}"
       actions = [
         "kms:Decrypt",
-        "kms:Encrypt",
-        "kms:GenerateDataKey*"
+        "kms:Encrypt"
       ]
       effect = "Allow"
       principals {
@@ -281,7 +280,10 @@ data "aws_iam_policy_document" "da_eventbus_kms_key" {
     effect  = "Allow"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+      identifiers = [
+        "arn:aws:iam::${var.account_id}:root",
+        aws_iam_role.success_destination_lambda.arn
+      ]
     }
     resources = ["*"]
   }

--- a/iam.tf
+++ b/iam.tf
@@ -60,6 +60,19 @@ data "aws_iam_policy_document" "tre_out_topic_policy" {
   }
 }
 
+data "aws_iam_policy_document" "tre_out_topic_policy" {
+  statement {
+    sid     = "DA-EventbusPublishers"
+    actions = ["sns:Publish"]
+    effect  = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = var.da_eventbus_publishers
+    }
+    resources = [aws_sns_topic.tre_out.arn]
+  }
+}
+
 data "aws_iam_policy_document" "tre_internal_topic_policy" {
   statement {
     sid     = "TRE-InternalPublishers"

--- a/iam.tf
+++ b/iam.tf
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "tre_out_topic_policy" {
   }
 }
 
-data "aws_iam_policy_document" "tre_out_topic_policy" {
+data "aws_iam_policy_document" "da_eventbus_topic_policy" {
   statement {
     sid     = "DA-EventbusPublishers"
     actions = ["sns:Publish"]
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "tre_out_topic_policy" {
       type        = "AWS"
       identifiers = var.da_eventbus_publishers
     }
-    resources = [aws_sns_topic.tre_out.arn]
+    resources = [aws_sns_topic.da_eventbus.arn]
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -261,7 +261,6 @@ data "aws_iam_policy_document" "da_eventbus_kms_key" {
     for_each = toset(
       concat(
         var.da_eventbus_client_account_ids,
-        var.da_eventbus_publishers,
         [aws_iam_role.success_destination_lambda.arn]
       )
     )

--- a/lambda.tf
+++ b/lambda.tf
@@ -56,7 +56,7 @@ resource "aws_lambda_function" "success_destination" {
   timeout       = 30
   environment {
     variables = {
-      "TRE_INTERNAL_TOPIC_ARN" = aws_sns_topic.tre_internal.arn
+      "DA_EVENTBUS_TOPIC_ARN" = aws_sns_topic.da_eventbus.arn
     }
   }
   tracing_config {

--- a/output.tf
+++ b/output.tf
@@ -23,6 +23,16 @@ output "common_tre_out_topic_kms_arn" {
   description = "Common TRE out topic kms arn"
 }
 
+output "common_da_eventbus_topic_arn" {
+  value       = aws_sns_topic.da_eventbus.arn
+  description = "Common DA eventbus topic arn"
+}
+
+output "common_da_eventbus_topic_kms_arn" {
+  value       = aws_kms_key.da_eventbus.arn
+  description = "Common DA eventbus topic kms arn"
+}
+
 output "tre_dlq_alerts_lambda_function_name" {
   value       = aws_lambda_function.tre_dlq_slack_alerts.function_name
   description = "TRE DLQ Alerts Lambda Function Name"

--- a/sns.tf
+++ b/sns.tf
@@ -90,3 +90,14 @@ resource "aws_sns_topic_policy" "da_eventbus" {
   arn    = aws_sns_topic.da_eventbus.arn
   policy = data.aws_iam_policy_document.da_eventbus_topic_policy.json
 }
+
+resource "aws_sns_topic_subscription" "da_eventbus" {
+  for_each              = { for sub in var.da_eventbus_subscriptions : sub.name => sub }
+  topic_arn             = aws_sns_topic.da_eventbus.arn
+  protocol              = each.value.protocol
+  endpoint              = each.value.endpoint
+  filter_policy         = each.value.filter_policy
+  filter_policy_scope   = each.value.filter_policy_scope
+  raw_message_delivery  = each.value.raw_message_delivery
+  subscription_role_arn = each.value.subscription_role_arn
+}

--- a/sns.tf
+++ b/sns.tf
@@ -98,6 +98,4 @@ resource "aws_sns_topic_subscription" "da_eventbus" {
   endpoint              = each.value.endpoint
   filter_policy         = each.value.filter_policy
   filter_policy_scope   = each.value.filter_policy_scope
-  raw_message_delivery  = each.value.raw_message_delivery
-  subscription_role_arn = each.value.subscription_role_arn
 }

--- a/sns.tf
+++ b/sns.tf
@@ -79,8 +79,14 @@ resource "aws_sns_topic_subscription" "tre_out" {
   subscription_role_arn = each.value.subscription_role_arn
 }
 
+# DA Eventbus SNS Topic
 
 resource "aws_sns_topic" "da_eventbus" {
   name              = "${var.env}-da-eventbus"
   kms_master_key_id = aws_kms_key.da_eventbus.arn
+}
+
+resource "aws_sns_topic_policy" "da_eventbus" {
+  arn    = aws_sns_topic.da_eventbus.arn
+  policy = data.aws_iam_policy_document.da_eventbus_topic_policy.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,5 @@ variable "da_eventbus_subscriptions" {
     protocol              = string
     filter_policy         = any
     filter_policy_scope   = string
-    subscription_role_arn = string
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -155,7 +155,6 @@ variable "da_eventbus_subscriptions" {
     protocol              = string
     filter_policy         = any
     filter_policy_scope   = string
-    raw_message_delivery  = bool
     subscription_role_arn = string
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -147,4 +147,15 @@ variable "da_eventbus_client_account_ids" {
   type = list(string)
 }
 
-
+variable "da_eventbus_subscriptions" {
+  description = "List tre-da-eventbus topic subscriptions"
+  type = list(object({
+    name                  = string
+    endpoint              = string
+    protocol              = string
+    filter_policy         = any
+    filter_policy_scope   = string
+    raw_message_delivery  = bool
+    subscription_role_arn = string
+  }))
+}

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,11 @@ variable "tre_out_publishers" {
   type        = list(string)
 }
 
+variable "da_eventbus_publishers" {
+  description = "Roles that have permission to publish messages to da-eventbus topic"
+  type        = list(string)
+}
+
 variable "tre_in_subscriptions" {
   description = "List tre-in topic subscriptions"
   type = list(object({


### PR DESCRIPTION
As part of the switchover to the new event bus architecture, we now need to subscribe a set of queues to the da event bus topic (supplied in da-tre-terraform-environments), and switch our success destination from publishing to our internal sns topic to publishing to the new event bus.

This sets up a subscribers variable and generates the relevant subscriptions and associated policies, as well as updating the env var for the success destination lambda.