### PR TITLE
fix/allow failure destination to publish to eventbus

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -158,7 +158,8 @@ data "aws_iam_policy_document" "da_eventbus_kms_key" {
       type        = "AWS"
       identifiers = concat([
         "arn:aws:iam::${var.account_id}:root",
-        aws_iam_role.success_destination_lambda.arn
+        aws_iam_role.success_destination_lambda.arn,
+        aws_iam_role.failure_destination_lambda.arn
       ], var.da_eventbus_publishers)
     }
     resources = ["*"]

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "common_tre_slack_alerts" {
-  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}${var.prefix}-slack-alerts:${var.common_image_versions.tre_slack_alerts}"
+  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}da-${var.prefix}-slack-notifications:${var.common_image_versions.tre_slack_alerts}"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-common-slack-alerts"
   role          = aws_iam_role.common_tre_slack_alerts_lambda_role.arn

--- a/lambda.tf
+++ b/lambda.tf
@@ -4,6 +4,7 @@ resource "aws_lambda_function" "common_tre_slack_alerts" {
   function_name = "${var.env}-${var.prefix}-common-slack-alerts"
   role          = aws_iam_role.common_tre_slack_alerts_lambda_role.arn
   timeout       = 30
+  memory_size   = 1024
   environment {
     variables = {
       "SLACK_WEBHOOK_URL" = var.slack_webhook_url

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "common_tre_slack_alerts" {
-  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}da-${var.prefix}-slack-notifications:${var.common_image_versions.tre_slack_alerts}"
+  image_uri     = "${var.ecr_uri_host}/${var.ecr_uri_repo_prefix}da-${var.prefix}-fn-slack-notifications:${var.common_image_versions.tre_slack_alerts}"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-common-slack-alerts"
   role          = aws_iam_role.common_tre_slack_alerts_lambda_role.arn

--- a/lambda.tf
+++ b/lambda.tf
@@ -23,7 +23,7 @@ resource "aws_lambda_permission" "common_tre_slack_alerts_sns_trigger_permission
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.common_tre_slack_alerts.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.common_tre_slack_alerts.arn
+  source_arn    = aws_sns_topic.da_eventbus.arn
 }
 
 # TRE dlq alerts

--- a/sns.tf
+++ b/sns.tf
@@ -9,7 +9,7 @@ resource "aws_sns_topic_policy" "common_tre_slack_alerts" {
 }
 
 resource "aws_sns_topic_subscription" "common_tre_slack_alerts" {
-  topic_arn = aws_sns_topic.common_tre_slack_alerts.arn
+  topic_arn = aws_sns_topic.da_eventbus.arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.common_tre_slack_alerts.arn
 }


### PR DESCRIPTION
- feat: Switch tre-slack alerts to subscribe to the eventbus
- Fix typo in image name
- Update lambda permission
- Bump memory
- fix: Allow failure destination lambda to publish to eventbus
