### PR TITLE
TDRD-755: also allow sns list on eventbus

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -124,7 +124,8 @@ data "aws_iam_policy_document" "da_eventbus_topic_policy" {
       sid = "da-event-bus-client-${statement.value}"
       actions = [
         "sns:Publish",
-        "sns:Subscribe"
+        "sns:Subscribe",
+        "sns:List*"
       ]
       effect = "Allow"
       principals {
@@ -139,7 +140,8 @@ data "aws_iam_policy_document" "da_eventbus_topic_policy" {
     sid = "account-${var.env}-eventbus-client"
     actions = [
       "sns:Publish",
-      "sns:Subscribe"
+      "sns:Subscribe",
+      "sns:List*"
     ]
     effect = "Allow"
     principals {


### PR DESCRIPTION
Cross account ids in `var.da_eventbus_client_account_ids` (https://github.com/nationalarchives/da-tre-tf-module-common/blob/085e3f797ecae0edeae49f799c743b3f38877ba5/iam.tf#L116C7-L116C40 ) as defined here https://github.com/nationalarchives/da-tre-terraform-environments/blob/main/vars/int.tfvars.json#L28-L34 are currently allowed to subscribe and publish to eventbus.  

This change will additionally allow them to `sns:List*` 

Requested by AYR to deal with issue:

> It's a recent change in terraform which caused this
> SNS:ListSubscriptionsByTopic  is now required
> But I think they are saying it's a bug and has a fix which hasn't been released
> This actually broke our pipeline and we aren't able to run terraform plan/apply
